### PR TITLE
Introduce pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "next": "^13.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-intersection-observer": "^9.4.3",
     "zod": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aerial-ops-chat-app",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ dependencies:
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
+  react-intersection-observer:
+    specifier: ^9.4.3
+    version: 9.4.3(react@18.2.0)
   zod:
     specifier: ^3.0.0
     version: 3.20.2
@@ -2655,6 +2658,14 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+    dev: false
+
+  /react-intersection-observer@9.4.3(react@18.2.0):
+    resolution: {integrity: sha512-WNRqMQvKpupr6MzecAQI0Pj0+JQong307knLP4g/nBex7kYfIaZsPpXaIhKHR+oV8z+goUbH9e10j6lGRnTzlQ==}
+    peerDependencies:
+      react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
     dev: false
 
   /react-is@16.13.1:

--- a/src/components/MessageBar.tsx
+++ b/src/components/MessageBar.tsx
@@ -13,7 +13,7 @@ export default function MessageBar(props: MessageBarProps) {
 
   const { refetch } = props;
 
-  const mutation = trpc.addMsg.useMutation({ onSettled: refetch });
+  const { mutate } = trpc.addMsg.useMutation({ onSettled: refetch });
   const preSignedUrl = trpc.getPresignedUrl.useQuery(
     { filename, fileType },
     { enabled: !!filename && !!fileType },
@@ -23,8 +23,8 @@ export default function MessageBar(props: MessageBarProps) {
     if (file) {
       const imageUrl = await uploadPhotoToS3();
       if (!imageUrl) return;
-      mutation.mutate({ type: 'WITH_IMAGE', text, imageUrl });
-    } else mutation.mutate({ type: 'WITHOUT_IMAGE', text });
+      mutate({ type: 'WITH_IMAGE', text, imageUrl });
+    } else mutate({ type: 'WITHOUT_IMAGE', text });
     setText('');
     setFilename('');
     setFileType('');

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, CSSProperties } from 'react';
 import { ObjectId } from 'mongodb';
 import { useInView } from 'react-intersection-observer';
-import { ScrollArea } from '@mantine/core';
+import { ScrollArea, Loader } from '@mantine/core';
 import { IconTrash } from '@tabler/icons-react';
 import { trpc } from '~/utils/trpc';
 import { MessagesProps } from '~/utils/types';
@@ -9,7 +9,7 @@ import { MessagesProps } from '~/utils/types';
 export default function Messages(props: MessagesProps) {
   const [msgId, setMsgId] = useState<ObjectId | null>(null); // track which msg is being hovered
   const { ref, inView } = useInView();
-  const { allMsgs, refetch, fetchNextPage } = props;
+  const { allMsgs, isFetchingNextPage, refetch, fetchNextPage } = props;
 
   const { mutate } = trpc.deleteMsg.useMutation({ onSettled: refetch });
 
@@ -54,6 +54,9 @@ export default function Messages(props: MessagesProps) {
           </div>
         );
       })}
+      {isFetchingNextPage ? (
+        <Loader style={loaderStyle} variant='dots' size='lg' />
+      ) : null}
       <div ref={ref}></div>
     </ScrollArea>
   );
@@ -88,4 +91,9 @@ const timestampStyle: CSSProperties = {
 
 const trashIcon: CSSProperties = {
   color: '#9da2a4',
+};
+
+const loaderStyle: CSSProperties = {
+  display: 'block',
+  margin: '0px auto 20px',
 };

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -9,7 +9,7 @@ import { MessagesProps } from '~/utils/types';
 export default function Messages(props: MessagesProps) {
   const [msgId, setMsgId] = useState<ObjectId | null>(null); // track which msg is being hovered
   const { ref, inView } = useInView();
-  const { msgs, refetch } = props;
+  const { msgs, refetch, fetchNextPage } = props;
 
   const mutation = trpc.deleteMsg.useMutation({ onSettled: refetch });
 
@@ -26,7 +26,7 @@ export default function Messages(props: MessagesProps) {
   }
 
   useEffect(() => {
-    if (inView) refetch();
+    if (inView) fetchNextPage();
   }, [inView]);
 
   return (

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -9,7 +9,7 @@ import { MessagesProps } from '~/utils/types';
 export default function Messages(props: MessagesProps) {
   const [msgId, setMsgId] = useState<ObjectId | null>(null); // track which msg is being hovered
   const { ref, inView } = useInView();
-  const { msgs, refetch, fetchNextPage } = props;
+  const { allMsgs, refetch, fetchNextPage } = props;
 
   const mutation = trpc.deleteMsg.useMutation({ onSettled: refetch });
 
@@ -31,7 +31,7 @@ export default function Messages(props: MessagesProps) {
 
   return (
     <ScrollArea h={400}>
-      {msgs?.map((msg) => {
+      {allMsgs?.map((msg) => {
         return (
           <div style={msgWrapStyle} key={msg._id.toString()}>
             {msg.imageUrl ? (

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -11,11 +11,11 @@ export default function Messages(props: MessagesProps) {
   const { ref, inView } = useInView();
   const { allMsgs, refetch, fetchNextPage } = props;
 
-  const mutation = trpc.deleteMsg.useMutation({ onSettled: refetch });
+  const { mutate } = trpc.deleteMsg.useMutation({ onSettled: refetch });
 
   function deleteMsg(_id: ObjectId) {
     const idAsString = _id.toString();
-    mutation.mutate({ id: idAsString });
+    mutate({ id: idAsString });
   }
 
   function formatTimestamp(unixTimestamp: number) {

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -1,5 +1,6 @@
-import { useState, CSSProperties } from 'react';
+import { useState, useEffect, CSSProperties } from 'react';
 import { ObjectId } from 'mongodb';
+import { useInView } from 'react-intersection-observer';
 import { ScrollArea } from '@mantine/core';
 import { IconTrash } from '@tabler/icons-react';
 import { trpc } from '~/utils/trpc';
@@ -7,7 +8,7 @@ import { MessagesProps } from '~/utils/types';
 
 export default function Messages(props: MessagesProps) {
   const [msgId, setMsgId] = useState<ObjectId | null>(null); // track which msg is being hovered
-
+  const { ref, inView } = useInView();
   const { msgs, refetch } = props;
 
   const mutation = trpc.deleteMsg.useMutation({ onSettled: refetch });
@@ -23,6 +24,10 @@ export default function Messages(props: MessagesProps) {
     const time = dateString.slice(16, 21);
     return `${date} - ${time}`;
   }
+
+  useEffect(() => {
+    if (inView) refetch();
+  }, [inView]);
 
   return (
     <ScrollArea h={400}>
@@ -49,6 +54,7 @@ export default function Messages(props: MessagesProps) {
           </div>
         );
       })}
+      <div ref={ref}></div>
     </ScrollArea>
   );
 }

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -32,25 +32,24 @@ export default function Messages(props: MessagesProps) {
   return (
     <ScrollArea h={400}>
       {allMsgs?.map((msg) => {
+        const { _id, text, unixTime, imageUrl } = msg;
         return (
-          <div style={msgWrapStyle} key={msg._id.toString()}>
-            {msg.imageUrl ? (
-              <img style={imageStyle} src={msg.imageUrl} />
-            ) : null}
+          <div style={msgWrapStyle} key={_id.toString()}>
+            {imageUrl ? <img style={imageStyle} src={imageUrl} /> : null}
             <div
               style={msgIconStyle}
-              onMouseEnter={() => setMsgId(msg._id)}
+              onMouseEnter={() => setMsgId(_id)}
               onMouseLeave={() => setMsgId(null)}
             >
-              <div style={msgStyle}>{msg.text}</div>
+              <div style={msgStyle}>{text}</div>
               <IconTrash
                 style={trashIcon}
-                onClick={() => deleteMsg(msg._id)}
-                visibility={msgId === msg._id ? 'visible' : 'hidden'}
+                onClick={() => deleteMsg(_id)}
+                visibility={msgId === _id ? 'visible' : 'hidden'}
                 onMouseOver={(e) => (e.currentTarget.style.cursor = 'pointer')}
               />
             </div>
-            <div style={timestampStyle}>{formatTimestamp(msg.unixTime)}</div>
+            <div style={timestampStyle}>{formatTimestamp(unixTime)}</div>
           </div>
         );
       })}

--- a/src/pages/api/crud.ts
+++ b/src/pages/api/crud.ts
@@ -58,6 +58,6 @@ export async function listMsgs(
   const lastItem = msgs[msgs.length - 1];
   let lastCursor: string | undefined;
   if (sortType === 'date') lastCursor = lastItem?._id.toString();
-  else lastCursor = lastItem?._id.toString();
+  else lastCursor = lastItem?.text.toString();
   return { msgs, lastCursor };
 }

--- a/src/pages/api/trpc/[trpc].ts
+++ b/src/pages/api/trpc/[trpc].ts
@@ -24,8 +24,9 @@ const appRouter = router({
       ]),
     )
     .mutation(({ input }) => {
-      if (input.type === 'WITHOUT_IMAGE') addMsg(input.text);
-      else addMsg(input.text, input.imageUrl);
+      const { type, text } = input;
+      if (type === 'WITHOUT_IMAGE') addMsg(text);
+      else addMsg(text, input.imageUrl);
     }),
   deleteMsg: publicProcedure
     .input(
@@ -34,7 +35,8 @@ const appRouter = router({
       }),
     )
     .mutation(({ input }) => {
-      deleteMsg(input.id);
+      const { id } = input;
+      deleteMsg(id);
     }),
   listMsgs: publicProcedure
     .input(
@@ -45,7 +47,8 @@ const appRouter = router({
       }),
     )
     .query(({ input }) => {
-      return listMsgs(input.sortType, input.isSortedAsc, input.cursor);
+      const { sortType, isSortedAsc, cursor } = input;
+      return listMsgs(sortType, isSortedAsc, cursor);
     }),
   getPresignedUrl: publicProcedure
     .input(
@@ -55,7 +58,8 @@ const appRouter = router({
       }),
     )
     .query(({ input }) => {
-      return preSignedUrl(input.filename, input.fileType);
+      const { filename, fileType } = input;
+      return preSignedUrl(filename, fileType);
     }),
 });
 

--- a/src/pages/api/trpc/[trpc].ts
+++ b/src/pages/api/trpc/[trpc].ts
@@ -41,10 +41,11 @@ const appRouter = router({
       z.object({
         sortType: z.string().nullish(),
         isSortedAsc: z.boolean(),
+        cursor: z.string().nullish(),
       }),
     )
     .query(({ input }) => {
-      return listMsgs(input.sortType, input.isSortedAsc);
+      return listMsgs(input.sortType, input.isSortedAsc, input.cursor);
     }),
   getPresignedUrl: publicProcedure
     .input(

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,11 +13,14 @@ export default function IndexPage() {
   const [sortType, setSortType] = useState<string | null>('date');
   const [isSortedAsc, setIsSortedAsc] = useState(true);
 
-  const { data, refetch } = trpc.listMsgs.useQuery(
+  const { data, refetch } = trpc.listMsgs.useInfiniteQuery(
     { sortType, isSortedAsc },
-    { refetchInterval: 2500 },
+    { getNextPageParam: (lastPage) => lastPage.lastCursor },
   );
-  const msgs = data as unknown as Message[];
+  let allMsgs: Message[] = [];
+  data?.pages.forEach((page) => {
+    page.msgs.forEach((msg) => allMsgs.push(msg as unknown as Message));
+  });
 
   return (
     <Container style={styles}>
@@ -27,7 +30,7 @@ export default function IndexPage() {
         isSortedAsc={isSortedAsc}
         setIsSortedAsc={setIsSortedAsc}
       />
-      <Messages msgs={msgs} refetch={refetch} />
+      <Messages msgs={allMsgs} refetch={refetch} />
       <MessageBar refetch={refetch} />
     </Container>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,10 +13,11 @@ export default function IndexPage() {
   const [sortType, setSortType] = useState<string | null>('date');
   const [isSortedAsc, setIsSortedAsc] = useState(true);
 
-  const { data, refetch, fetchNextPage } = trpc.listMsgs.useInfiniteQuery(
-    { sortType, isSortedAsc },
-    { getNextPageParam: (lastPage) => lastPage.lastCursor },
-  );
+  const { data, isFetchingNextPage, refetch, fetchNextPage } =
+    trpc.listMsgs.useInfiniteQuery(
+      { sortType, isSortedAsc },
+      { getNextPageParam: (lastPage) => lastPage.lastCursor },
+    );
   let allMsgs: Message[] = [];
   data?.pages.forEach((page) => {
     page.msgs.forEach((msg) => allMsgs.push(msg as unknown as Message));
@@ -32,6 +33,7 @@ export default function IndexPage() {
       />
       <Messages
         allMsgs={allMsgs}
+        isFetchingNextPage={isFetchingNextPage}
         refetch={refetch}
         fetchNextPage={fetchNextPage}
       />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,7 +13,7 @@ export default function IndexPage() {
   const [sortType, setSortType] = useState<string | null>('date');
   const [isSortedAsc, setIsSortedAsc] = useState(true);
 
-  const { data, refetch } = trpc.listMsgs.useInfiniteQuery(
+  const { data, refetch, fetchNextPage } = trpc.listMsgs.useInfiniteQuery(
     { sortType, isSortedAsc },
     { getNextPageParam: (lastPage) => lastPage.lastCursor },
   );
@@ -30,7 +30,11 @@ export default function IndexPage() {
         isSortedAsc={isSortedAsc}
         setIsSortedAsc={setIsSortedAsc}
       />
-      <Messages msgs={allMsgs} refetch={refetch} />
+      <Messages
+        msgs={allMsgs}
+        refetch={refetch}
+        fetchNextPage={fetchNextPage}
+      />
       <MessageBar refetch={refetch} />
     </Container>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -31,7 +31,7 @@ export default function IndexPage() {
         setIsSortedAsc={setIsSortedAsc}
       />
       <Messages
-        msgs={allMsgs}
+        allMsgs={allMsgs}
         refetch={refetch}
         fetchNextPage={fetchNextPage}
       />

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,6 @@
 // Amazon Web Services
 export const S3_BUCKET_NAME = 'aerial-ops-chat-app';
 export const AWS_ID = 'AKIARB7FMSXCBWGYX7E5'; // IAM user
+
+// Miscellaneous
+export const NUM_MSGS = 5; // number of messages per query

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -3,4 +3,4 @@ export const S3_BUCKET_NAME = 'aerial-ops-chat-app';
 export const AWS_ID = 'AKIARB7FMSXCBWGYX7E5'; // IAM user
 
 // Miscellaneous
-export const NUM_MSGS = 5; // number of messages per query
+export const NUM_MSGS = 7; // number of messages per query

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -10,7 +10,7 @@ export type Message = {
 };
 
 export type MessagesProps = {
-  msgs: Message[];
+  allMsgs: Message[];
   refetch: () => void;
   fetchNextPage: () => void;
 };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -12,6 +12,7 @@ export type Message = {
 export type MessagesProps = {
   msgs: Message[];
   refetch: () => void;
+  fetchNextPage: () => void;
 };
 
 export type MessageBarProps = {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -11,6 +11,7 @@ export type Message = {
 
 export type MessagesProps = {
   allMsgs: Message[];
+  isFetchingNextPage: boolean;
   refetch: () => void;
   fetchNextPage: () => void;
 };


### PR DESCRIPTION
Allows infinite scrolling through the `useInfiniteQuery` tRPC hook. Messages are fetched in batches of seven. A new request is triggered when the user reaches the bottom of their feed.

_Note:_ The way `$gt` and `$lt` work in MongoDB mean that uppercase letters come before lowercase ones. So when sorted by text in ascending order, a message starting with 'Z' will be listed before one starting with 'a'. No effort was made to change this default behaviour.